### PR TITLE
updated constants.dart

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,1 +1,3 @@
-const String apiKey = '58b98b48d2c74d9c94dd5dc296ccf7b6';
+class AppConstants {
+ static const String apiKey = '58b98b48d2c74d9c94dd5dc296ccf7b6';
+}


### PR DESCRIPTION
You should keep constants in a class as static const so they don't compile over and over.